### PR TITLE
Inline if statement for post type detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.bundle/
+
 /_assets/images/theboldreport-logo.svg
 
 /_drafts/sponsor*

--- a/atom.xml
+++ b/atom.xml
@@ -16,34 +16,18 @@ layout: nil
   </author>
 
   {% for post in site.posts %}
-    {% if post.custom_type == 'post' %}
-      <entry>
-        <id>http://theboldreport.net{{ post.id }}</id>
-        <link type="text/html" rel="alternate" href="http://theboldreport.net{{ post.url }}"/>
-        <title>♨ {{ post.title }}</title>
-        <published>{{ post.date | date_to_xmlschema }}</published>
-        <updated>{{ post.date | date_to_xmlschema }}</updated>
-        <author>
-          <name>Tim Smith</name>
-          <uri>http://ttimsmith.com/</uri>
-        </author>
-        <content type="html">{{ post.content | xml_escape }}</content>
-      </entry>
-
-    {% elsif post.custom_type == 'link' %}
-      <entry>
-        <id>http://theboldreport.net{{ post.id }}</id>
-        <link type="text/html" rel="alternate" href="http://theboldreport.net{{ post.url }}"/>
-        <title>{{ post.title }}</title>
-        <published>{{ post.date | date_to_xmlschema }}</published>
-        <updated>{{ post.date | date_to_xmlschema }}</updated>
-        <author>
-          <name>Tim Smith</name>
-          <uri>http://ttimsmith.com/</uri>
-        </author>
-        <content type="html">{{ post.content | xml_escape }}</content>
-      </entry>
-    {% endif %}
+    <entry>
+      <id>http://theboldreport.net{{ post.id }}</id>
+      <link type="text/html" rel="alternate" href="http://theboldreport.net{{ post.url }}"/>
+      <title>{{ '♨ ' if post.custom_type == 'post' else '' }}{{ post.title }}</title>
+      <published>{{ post.date | date_to_xmlschema }}</published>
+      <updated>{{ post.date | date_to_xmlschema }}</updated>
+      <author>
+        <name>Tim Smith</name>
+        <uri>http://ttimsmith.com/</uri>
+      </author>
+      <content type="html">{{ post.content | xml_escape }}</content>
+    </entry>
   {% endfor %}
 
 </feed>


### PR DESCRIPTION
(I haven’t tested this because Bundler was acting up and I’m too sleepy to deal with it, but I’m fairly confident it’ll work beautifully.)

You can basically half the code required for your custom post feed prefixer by using an inline `if` instead of blocks.
