### PR TITLE
Fix images classes for Safari

### DIFF
--- a/_assets/stylesheets/_redbat/_images.scss
+++ b/_assets/stylesheets/_redbat/_images.scss
@@ -57,8 +57,8 @@ figcaption {
   }
   img {
     @media #{$medium-up} {
-      width: 70%;
       flex: 0 0 70%;
+      width: 70%;
     }
   }
   figcaption {
@@ -86,8 +86,8 @@ figcaption {
   }
   img {
     @media #{$medium-up} {
-      width: 70%;
       flex: 0 0 70%;
+      width: 70%;
     }
   }
   figcaption {

--- a/_assets/stylesheets/_redbat/_images.scss
+++ b/_assets/stylesheets/_redbat/_images.scss
@@ -4,7 +4,7 @@
 
 img {
   height: auto;
-  width: 100%;
+  max-width: 100%;
 }
 
 .border--white {
@@ -58,6 +58,7 @@ figcaption {
   img {
     @media #{$medium-up} {
       width: 70%;
+      flex: 0 0 70%;
     }
   }
   figcaption {
@@ -86,6 +87,7 @@ figcaption {
   img {
     @media #{$medium-up} {
       width: 70%;
+      flex: 0 0 70%;
     }
   }
   figcaption {

--- a/_assets/stylesheets/_redbat/_type.scss
+++ b/_assets/stylesheets/_redbat/_type.scss
@@ -243,9 +243,7 @@ blockquote {
       content: '—';
     }
   }
-  > blockquote,
-  > ol,
-  > ul {
+  > blockquote, > ol, > ul {
     width: 100%;
   }
 }

--- a/_assets/stylesheets/_redbat/_type.scss
+++ b/_assets/stylesheets/_redbat/_type.scss
@@ -243,7 +243,9 @@ blockquote {
       content: '—';
     }
   }
-  > blockquote, > ol, > ul {
+  > blockquote,
+  > ol,
+  > ul {
     width: 100%;
   }
 }


### PR DESCRIPTION
#### Purpose

The `.alignright` and `.alignleft` classes weren't working in Safari, so I fixed them

:coffee:

